### PR TITLE
Drastically improve performance of volume calculation

### DIFF
--- a/Source/ChannelRemappingAudioSourceWithVolume.cpp
+++ b/Source/ChannelRemappingAudioSourceWithVolume.cpp
@@ -6,7 +6,7 @@ ChannelRemappingAudioSourceWithVolume::ChannelRemappingAudioSourceWithVolume(
     AudioSource* const source_, SoloBusSettings& soloBusSettings, const bool deleteSourceWhenDeleted)
     : source(source_, deleteSourceWhenDeleted)
     , requiredNumberOfChannels(2)
-    , m_bufferSize(1)
+    , m_decayRate(0)
     , m_soloBusSettings(soloBusSettings)
 {
     m_soloBusSettings.addListener(this);
@@ -26,7 +26,7 @@ void ChannelRemappingAudioSourceWithVolume::setNumberOfChannelsToProduce(int req
 
     if (requiredNumberOfChannels > m_volumes.size())
         m_volumes.insertMultiple(
-            m_volumes.size(), VolumeAnalyzer(m_bufferSize), requiredNumberOfChannels_ - m_volumes.size());
+            m_volumes.size(), VolumeAnalyzer(m_decayRate), requiredNumberOfChannels_ - m_volumes.size());
 }
 
 void ChannelRemappingAudioSourceWithVolume::clearAllMappings()
@@ -51,11 +51,11 @@ void ChannelRemappingAudioSourceWithVolume::prepareToPlay(int samplesPerBlockExp
     source->prepareToPlay(samplesPerBlockExpected, sampleRate);
 
     const ScopedLock sl(lock);
-    m_bufferSize = static_cast<size_t>(sampleRate / 10);
+    m_decayRate = static_cast<float>(sampleRate / 10);
     auto numberOfChannels = m_volumes.size();
     m_volumes.clear();
     if (numberOfChannels > m_volumes.size())
-        m_volumes.insertMultiple(m_volumes.size(), VolumeAnalyzer(m_bufferSize), numberOfChannels - m_volumes.size());
+        m_volumes.insertMultiple(m_volumes.size(), VolumeAnalyzer(m_decayRate), numberOfChannels - m_volumes.size());
     m_sampleRate = sampleRate;
 }
 

--- a/Source/ChannelRemappingAudioSourceWithVolume.h
+++ b/Source/ChannelRemappingAudioSourceWithVolume.h
@@ -25,7 +25,7 @@ public:
 
 private:
     Array<VolumeAnalyzer> m_volumes;
-    size_t m_bufferSize;
+    float m_decayRate;
     double m_sampleRate{0.0};
 
     // ChannelRemappingAudioSource

--- a/Source/ChannelVolumeAudioSource.cpp
+++ b/Source/ChannelVolumeAudioSource.cpp
@@ -99,10 +99,10 @@ float ChannelVolumeAudioSource::getActualVolume(int channelIndex) const
 void ChannelVolumeAudioSource::prepareToPlay(int samplesPerBlockExpected, double sampleRate)
 {
     m_source->prepareToPlay(samplesPerBlockExpected, sampleRate);
-    m_bufferSize = static_cast<size_t>(sampleRate / 10);
+    m_decayRate = static_cast<float>(sampleRate / 10);
     auto numberOfChannels = m_actualVolumes.size();
     m_actualVolumes.clear();
-    m_actualVolumes.insertMultiple(0, VolumeAnalyzer(m_bufferSize), numberOfChannels);
+    m_actualVolumes.insertMultiple(0, VolumeAnalyzer(m_decayRate), numberOfChannels);
 }
 
 void ChannelVolumeAudioSource::releaseResources()
@@ -120,7 +120,7 @@ void ChannelVolumeAudioSource::setChannelCount(int channelCount)
     if (channelCount > m_setMutes.size())
         m_setMutes.insertMultiple(m_setMutes.size(), false, channelCount);
     if (channelCount > m_actualVolumes.size())
-        m_actualVolumes.insertMultiple(m_actualVolumes.size(), VolumeAnalyzer(m_bufferSize), channelCount);
+        m_actualVolumes.insertMultiple(m_actualVolumes.size(), VolumeAnalyzer(m_decayRate), channelCount);
     if (channelCount > m_appliedGains.size())
         m_appliedGains.insertMultiple(m_appliedGains.size(), 1.0f, channelCount);
 }

--- a/Source/ChannelVolumeAudioSource.h
+++ b/Source/ChannelVolumeAudioSource.h
@@ -76,7 +76,7 @@ public:
 
 private:
     Array<VolumeAnalyzer> m_actualVolumes;
-    size_t m_bufferSize{0};
+    float m_decayRate{0};
 
     // gain to apply
 private:

--- a/Source/VolumeAnalyzer.cpp
+++ b/Source/VolumeAnalyzer.cpp
@@ -1,19 +1,23 @@
 #include "VolumeAnalyzer.h"
 
-VolumeAnalyzer::VolumeAnalyzer(size_t bufferSize)
-    : m_samples(bufferSize, 0.0f)
-    , m_writeIndex(0)
+VolumeAnalyzer::VolumeAnalyzer(float decayRate)
+    : m_decayRate(decayRate)
 {
-    jassert(bufferSize > 0);
 }
 
 float VolumeAnalyzer::getVolume() const
 {
-    return *std::max_element(m_samples.begin(), m_samples.end());
+    return m_volume;
 }
 
 void VolumeAnalyzer::update(const float* buffer, int numSamples)
 {
     for (int sampleIndex = 0; sampleIndex < numSamples; ++sampleIndex)
-        m_samples[++m_writeIndex % m_samples.size()] = std::abs(buffer[sampleIndex]);
+    {
+        float abs = std::abs(buffer[sampleIndex]);
+        if (abs >= m_volume)
+            m_volume = abs;
+        else
+            m_volume *= (1.0f - 1.0f / m_decayRate);
+    }
 }

--- a/Source/VolumeAnalyzer.h
+++ b/Source/VolumeAnalyzer.h
@@ -8,12 +8,12 @@
 class VolumeAnalyzer
 {
 public:
-    VolumeAnalyzer(size_t bufferSize);
+    VolumeAnalyzer(float decayRate);
 
     float getVolume() const;
     void update(const float* buffer, int numSamples);
 
 private:
-    std::vector<float> m_samples;
-    size_t m_writeIndex;
+    float m_decayRate;
+    float m_volume{};
 };


### PR DESCRIPTION
Until now the volume was calculated by keeping a circular buffer 1/10th
of the sample rate (i.e. 100 ms) and determining the absolute maximum
sample within it. This is immensly CPU-intensive because the maximum of
quite a lot of numbers needs to be recalculated very often.

The new approach was taken from the JUCE forum[1] which is much easier
to calculate. It will not be as "perfect" as the previous solution but
should be good enough.

[1] https://forum.juce.com/t/level-meter-feedback/31161/12