### PR TITLE
Fix crash when saving a project

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -830,7 +830,7 @@ void MainContentComponent::writeProjectFile()
     root->addChildElement(view);
 
     XmlElement* audio = new XmlElement("Audio");
-    audio->addChildElement(m_audioDeviceManager.createStateXml().get());
+    audio->addChildElement(m_audioDeviceManager.createStateXml().release());
     root->addChildElement(audio);
 
     XmlElement* channelNames = new XmlElement("ChannelNames");


### PR DESCRIPTION
The XmlElement must be kept alive while it's a child element of another
node. `get()` will therefore not suffice, the raw pointer must be taken
out of the unique_ptr returned by createStateXml.