### PR TITLE
Fix crash when configuring V1 and V2 plugins

### DIFF
--- a/Source/PluginLoader.cpp
+++ b/Source/PluginLoader.cpp
@@ -379,7 +379,8 @@ void PluginLoader::configure(size_t index)
 
     index -= pluginsV2.size();
 
-    pluginsV3[index].configureFunction();
+    if (index < pluginsV3.size())
+        pluginsV3[index].configureFunction();
 }
 
 void PluginLoader::playingStateChanged(const char* playerName, bool isPlaying)


### PR DESCRIPTION
If there is no V3 plugin but V1 or V2 plugins the `pluginsV3` vector was
accessed with an out of range index.