### PR TITLE
Fix jumping to position in waveform

### DIFF
--- a/Source/Waveform.cpp
+++ b/Source/Waveform.cpp
@@ -6,6 +6,7 @@ Waveform::Waveform(Colour color)
     , m_audioThumbnail(nullptr)
 {
     setBufferedToImage(true);
+    setInterceptsMouseClicks(false, false);
 }
 
 void Waveform::setAudioThumbnail(AudioThumbnail* audioThumbnail)


### PR DESCRIPTION
With Waveform being introduced in 03f04be088b the component grabbed all
mouse interaction, preventing TrackUi from handling clicks.

Fixed by making the component completely ignoring mouse interactions.