### PR TITLE
Actually build 64 bit executable

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ install:
     - cmd: git submodule update --init --recursive
 
 before_build:
-  - cmake -G "Visual Studio 16 2019" -A Win32 -B Build -S . -DVERSION=%APPVEYOR_BUILD_VERSION%
+  - cmake -G "Visual Studio 16 2019" -A x64 -B Build -S . -DVERSION=%APPVEYOR_BUILD_VERSION%
   # Run clang-format
   - ps: |
       $env:PATH="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\VC\VCPackages\;$env:PATH"


### PR DESCRIPTION
The intention with cdd36f6312f was to build a 64 bit executable but the
CMake call still said Win32.