### PR TITLE
Ensure correct player color is shown when stopped

### DIFF
--- a/Source/JinglePlayerWindow.cpp
+++ b/Source/JinglePlayerWindow.cpp
@@ -138,8 +138,12 @@ JinglePlayerWindow::JinglePlayerWindow(Player& player, TracksContainer* tracksCo
     };
     m_tracksContainer->addLongestDurationChangedCallback(longestDurationCallback);
 
-    Track::PlayingStateChangedCallback playingStateChangedCallback
-        = [&](bool isPlaying) { m_playButton.setImages(isPlaying ? m_stopImage.get() : m_playImage.get()); };
+    Track::PlayingStateChangedCallback playingStateChangedCallback = [&](bool isPlaying) {
+        m_playButton.setImages(isPlaying ? m_stopImage.get() : m_playImage.get());
+        m_blink = false;
+        updatePointColor();
+        repaint();
+    };
     m_tracksContainer->addPlayingStateChangedCallback(playingStateChangedCallback);
 }
 


### PR DESCRIPTION
There was a bug report that a JinglePlayer showed the alternate color
used during the blink animation that happens in the last 10 seconds of
playback.

The same situation arises reproducibly when the audio file is shorter
than 10 seconds and the millisecond part is greater than 500 ms. In that
case the alternate color for blinking is always shown when the playback
is stopped.

The fix for both is to reset `m_blink` at the end of the playback.