### PR TITLE
Support multiple MIDI devices for MTC

### DIFF
--- a/Source/MTCSender.h
+++ b/Source/MTCSender.h
@@ -10,15 +10,15 @@ public:
     MTCSender();
     ~MTCSender();
 
-    void setDevice(int deviceIndex);
-    int getDevice();
+    void setDevices(Array<MidiDeviceInfo> deviceInfos);
+    Array<MidiDeviceInfo> getDevices();
     void start();
     void pause();
     void stop();
     void setPosition(double position);
 
 private:
-    std::unique_ptr<MidiOutput> m_midiOutput;
+    std::vector<std::unique_ptr<MidiOutput>> outputs;
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MTCSender)
 
     // Used only in separate thread!
@@ -44,5 +44,4 @@ private:
     int m_second{0};
     int m_minute{0};
     int m_hour{0};
-    int m_deviceIndex{-1};
 };

--- a/Source/MidiConfiguration.h
+++ b/Source/MidiConfiguration.h
@@ -7,7 +7,6 @@
 class MidiConfigurationWindow
     : public DialogWindow
     , public Button::Listener
-    , public ComboBox::Listener
 {
 public:
     MidiConfigurationWindow(MTCSender& mtcSender);
@@ -18,25 +17,42 @@ public:
     // Button::Listener
     virtual void buttonClicked(Button* buttonThatWasClicked) override;
 
-    // ComboBox::Listener
-    virtual void comboBoxChanged(ComboBox* comboBoxThatHasChanged) override;
+private:
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MidiConfigurationWindow)
+};
+
+// This is built after ChannelSelectorListBox of AudioDeviceSelectorComponent
+class MidiDeviceSelectorListBox
+    : public ListBox
+    , private ListBoxModel
+{
+public:
+    MidiDeviceSelectorListBox(MTCSender& mtcSender);
+    int getNumRows() override;
+    void paintListBoxItem(int rowNumber, Graphics& g, int width, int height, bool rowIsSelected) override;
+    void listBoxItemClicked(int row, const MouseEvent& e) override;
+    void listBoxItemDoubleClicked(int row, const MouseEvent&) override;
+    void returnKeyPressed(int row) override;
+    void flipEnablement(int row);
+    int getTickX();
 
 private:
-    MTCSender& m_mtcSender;
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MidiConfigurationWindow)
+    Array<MidiDeviceInfo> devices;
+    SparseSet<int> indexes;
+    MTCSender& mtcSender;
 };
 
 class MidiConfigurationComponent : public Component
 {
 public:
-    MidiConfigurationComponent(MidiConfigurationWindow* parent, int selectedDevice);
+    MidiConfigurationComponent(MidiConfigurationWindow* parent, MTCSender& mtcSender);
     ~MidiConfigurationComponent();
 
     // Component
     virtual void resized() override;
 
 private:
-    std::unique_ptr<ComboBox> m_outputDevices;
+    MidiDeviceSelectorListBox deviceSelector;
     std::unique_ptr<TextButton> m_closeButton;
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MidiConfigurationComponent)
 };


### PR DESCRIPTION
Instead of a single device multiple MIDI devices can be configured now.
MTC messages are sent to every selected MIDI device.