### PR TITLE
Use .so file extension for plugins on Linux

### DIFF
--- a/Source/PluginLoader.cpp
+++ b/Source/PluginLoader.cpp
@@ -160,8 +160,13 @@ PluginLoader::PluginLoader(MyMultiDocumentPanel* pComponent)
 {
     component = pComponent;
 
+#ifdef WIN32
+    constexpr const char* pattern = "*.dll";
+#else
+    constexpr const char* pattern = "*.so";
+#endif
     juce::RangedDirectoryIterator directoryIterator(
-        juce::File::getSpecialLocation(juce::File::currentExecutableFile).getSiblingFile("plugins"), false, "*.dll");
+        juce::File::getSpecialLocation(juce::File::currentExecutableFile).getSiblingFile("plugins"), false, pattern);
     std::vector<juce::File> dlls;
 
     struct LoadFailure


### PR DESCRIPTION
MStarPlayer can be built on Linux and it works there. The usual file extension for shared libraries (which plugins are) is `.so` on Linux. Use that extension when searching for plugins so no awkward renaming to `.dll` is necessary.