### PR TITLE
Update clang-format to version 17

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Run clang-format
       uses: jidicula/clang-format-action@v4.13.0
       with:
-        clang-format-version: '14'
+        clang-format-version: '17'
         check-path: 'Source'
 
   build:


### PR DESCRIPTION
This is what Visual Studio 2022 ships with.