### PR TITLE
Allow quick (de)activation of output channels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ set_property(TARGET MStarPlayer PROPERTY
 target_sources(MStarPlayer PRIVATE
     Source/AudioConfiguration.cpp
     Source/AudioConfiguration.h
+    Source/AudioDeviceComponent.cpp
+    Source/AudioDeviceComponent.h
     Source/CDNamesComboBox.cpp
     Source/CDNamesComboBox.h
     Source/CDPlayer.cpp

--- a/Source/AudioConfiguration.cpp
+++ b/Source/AudioConfiguration.cpp
@@ -2,6 +2,8 @@
 
 #include "juce_audio_utils/juce_audio_utils.h"
 
+#include "AudioDeviceComponent.h"
+
 class ChannelNameTextEditor : public juce::TextEditor
 {
 public:
@@ -180,9 +182,8 @@ AudioConfigurationComponent::AudioConfigurationComponent(AudioConfigurationWindo
 
     addAndMakeVisible(&m_tabbedComponent);
 
-    juce::AudioDeviceSelectorComponent* selector
-        = new juce::AudioDeviceSelectorComponent(audioDeviceManager, 0, 0, 1, 64, false, false, false, false);
-    m_tabbedComponent.addTab(TRANS("Audio Device"), juce::Colour(0xffffffff), selector, true);
+    AudioDeviceComponent* audioDevice = new AudioDeviceComponent(audioDeviceManager);
+    m_tabbedComponent.addTab(TRANS("Audio Device"), juce::Colour(0xffffffff), audioDevice, true);
 
     m_tabbedComponent.addTab(TRANS("Channel Names"), juce::Colour(0xffffffff), &m_tableListBox, false);
     m_tableListBox.setColour(juce::ListBox::outlineColourId, juce::Colours::grey);

--- a/Source/AudioDeviceComponent.cpp
+++ b/Source/AudioDeviceComponent.cpp
@@ -1,0 +1,58 @@
+#include "AudioDeviceComponent.h"
+
+AudioDeviceComponent::AudioDeviceComponent(juce::AudioDeviceManager& audioDeviceManager)
+    : selector(audioDeviceManager, 0, 0, 1, 64, false, false, false, false)
+    , selectAllChannelsButton("selectAll")
+    , deselectAllChannelsButton("deselectAll")
+{
+    addAndMakeVisible(selectAllChannelsButton);
+    selectAllChannelsButton.setButtonText(TRANS("activate all channels"));
+    selectAllChannelsButton.addListener(this);
+    selectAllChannelsButton.setWantsKeyboardFocus(false);
+
+    addAndMakeVisible(deselectAllChannelsButton);
+    deselectAllChannelsButton.setButtonText(TRANS("deactivate all but first channel"));
+    deselectAllChannelsButton.addListener(this);
+    deselectAllChannelsButton.setWantsKeyboardFocus(false);
+
+    addAndMakeVisible(selector);
+}
+
+void AudioDeviceComponent::resized()
+{
+    const static int buttonHeight = 24;
+    const static int padding = 10;
+
+    const int buttonWidth = (getWidth() - 3 * padding) / 2;
+
+    selectAllChannelsButton.setBounds(padding, padding, buttonWidth, buttonHeight);
+    deselectAllChannelsButton.setBounds(2 * padding + buttonWidth, padding, buttonWidth, buttonHeight);
+
+    selector.setBounds(0, 2 * padding + buttonHeight, getWidth(), selector.getHeight());
+}
+
+void AudioDeviceComponent::buttonClicked(juce::Button* buttonThatWasClicked)
+{
+    if (buttonThatWasClicked == &selectAllChannelsButton)
+    {
+        juce::AudioDeviceManager& manager = selector.deviceManager;
+        juce::AudioDeviceManager::AudioDeviceSetup setup = manager.getAudioDeviceSetup();
+        setup.useDefaultOutputChannels = false;
+        for (int i = 0; i < manager.getCurrentAudioDevice()->getOutputChannelNames().size(); ++i)
+        {
+            setup.outputChannels.setBit(i);
+        }
+        manager.setAudioDeviceSetup(setup, true);
+    }
+    else if (buttonThatWasClicked == &deselectAllChannelsButton)
+    {
+        juce::AudioDeviceManager& manager = selector.deviceManager;
+        juce::AudioDeviceManager::AudioDeviceSetup setup = manager.getAudioDeviceSetup();
+        setup.useDefaultOutputChannels = false;
+        for (int i = 1; i < manager.getCurrentAudioDevice()->getOutputChannelNames().size(); ++i)
+        {
+            setup.outputChannels.clearBit(i);
+        }
+        manager.setAudioDeviceSetup(setup, true);
+    }
+}

--- a/Source/AudioDeviceComponent.h
+++ b/Source/AudioDeviceComponent.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "juce_audio_utils/juce_audio_utils.h"
+
+class AudioDeviceComponent
+    : public juce::Component
+    , public juce::Button::Listener
+{
+public:
+    AudioDeviceComponent(juce::AudioDeviceManager& audioDeviceManager);
+
+    // Component
+    void resized() override;
+
+    // Button::Listener
+    virtual void buttonClicked(juce::Button* buttonThatWasClicked) override;
+
+private:
+    juce::AudioDeviceSelectorComponent selector;
+    juce::TextButton selectAllChannelsButton;
+    juce::TextButton deselectAllChannelsButton;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioDeviceComponent)
+};

--- a/Translations/German.txt
+++ b/Translations/German.txt
@@ -28,6 +28,10 @@ countries:de
 "Audio buffer size:" = "Größe des Audiobuffers:"
 "Audio device type:" = "Typ des Audiogeräts:"
 
+// AudioDeviceComponent
+"activate all channels" = "alle Kanäle aktivieren"
+"deactivate all but first channel" = "alle außer erstem Kanal deaktivieren"
+
 // General
 "Close" = "Schließen"
 


### PR DESCRIPTION
For audio devices with a high number of output channels it can be tedious having to activate or deactivate most channels. Offer buttons to do either very quickly so users only need to activate or deactivate a few more channels.

The first channel won't be deactivated since JUCE requires at least one channel to be active.