### PR TITLE
Fix crash with empty track

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,4 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Output channels can be activated and deactivated with one button click
 * Show *about* dialog with version number.
 
+### Fixed
+
+* Fixed crash when playing, pausing or stopping a player with at least one empty track.
+
 ## [1.1.111] - 2022-10-12

--- a/Source/Track.cpp
+++ b/Source/Track.cpp
@@ -128,10 +128,17 @@ float Track::getVolume() const
 
 void Track::play()
 {
-    setPosition(0);
-    m_transportSource.start();
-    startTimer(50);
-    m_playingStateChangedCallback(true);
+    if (m_currentAudioFileSource)
+    {
+        setPosition(0);
+        m_transportSource.start();
+        startTimer(50);
+        m_playingStateChangedCallback(true);
+    }
+    else
+    {
+        m_playingStateChangedCallback(false);
+    }
 }
 
 void Track::pause()
@@ -142,18 +149,25 @@ void Track::pause()
         stopTimer();
         m_playingStateChangedCallback(false);
     }
-    else
+    else if (m_currentAudioFileSource)
     {
         m_transportSource.start();
         startTimer(50);
         m_playingStateChangedCallback(true);
     }
+    else
+    {
+        m_playingStateChangedCallback(false);
+    }
 }
 
 void Track::stop()
 {
-    m_transportSource.stop();
-    setPosition(0);
+    if (m_currentAudioFileSource)
+    {
+        m_transportSource.stop();
+        setPosition(0);
+    }
     stopTimer();
     m_playingStateChangedCallback(false);
 }


### PR DESCRIPTION
When a track hasn't loaded a file the `m_transportSource` won't contain a source and thus crashes on some interactions (but not on others). Protect the calls by first checking whether an audio file was loaded.

Also call the *playing state changed* callback since the caller assumes the change actually changed so it needs to be "reset" for the UI to match the actual behavior.