### PR TITLE
Support panning stereo player tracks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,8 @@ target_sources(MStarPlayer PRIVATE
     Source/MyMultiDocumentPanel.h
     Source/OutputChannelNames.cpp
     Source/OutputChannelNames.h
+    Source/PanSlider.cpp
+    Source/PanSlider.h
     Source/PinkLookAndFeel.cpp
     Source/PinkLookAndFeel.h
     Source/Player.cpp

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Output channels can be activated and deactivated with one button click
 * Show *about* dialog with version number.
+* Support panning of stereo tracks.
 
 ### Fixed
 

--- a/Source/ChannelRemappingAudioSourceWithVolume.cpp
+++ b/Source/ChannelRemappingAudioSourceWithVolume.cpp
@@ -83,8 +83,11 @@ void ChannelRemappingAudioSourceWithVolume::getNextAudioBlock(const juce::AudioS
 
             if (remappedChan >= 0 && remappedChan < numChans)
             {
+                float gain = 1.0f;
+                if (remappedChan < sourceChannelGain.size())
+                    gain = sourceChannelGain.getReference(remappedChan);
                 bufferToFill.buffer->addFrom(
-                    remappedChan, bufferToFill.startSample, buffer, i, 0, bufferToFill.numSamples);
+                    remappedChan, bufferToFill.startSample, buffer, i, 0, bufferToFill.numSamples, gain);
             }
         }
 
@@ -166,6 +169,14 @@ void ChannelRemappingAudioSourceWithVolume::setOutputChannelMapping(int sourceCh
 {
     const juce::ScopedLock sl(lock);
     setOutputChannelMappingInternal(sourceChannelIndex, destChannelIndex, false);
+}
+
+void ChannelRemappingAudioSourceWithVolume::setSourceChannelGain(int sourceIndex, float gain)
+{
+    while (sourceChannelGain.size() < sourceIndex + 1)
+        sourceChannelGain.add(1.0f);
+
+    sourceChannelGain.getReference(sourceIndex) = gain;
 }
 
 void ChannelRemappingAudioSourceWithVolume::setOutputChannelMappingInternal(

--- a/Source/ChannelRemappingAudioSourceWithVolume.h
+++ b/Source/ChannelRemappingAudioSourceWithVolume.h
@@ -48,6 +48,8 @@ public:
     */
     void setOutputChannelMapping(int sourceChannelIndex, int destChannelIndex);
 
+    void setSourceChannelGain(int sourceChannelIndex, float gain);
+
     void setOutputChannelMappingInternal(const int sourceIndex, const int destIndex, const bool solo);
 
     /** Returns the output channel to which channel outputChannelIndex of our input audio
@@ -76,6 +78,7 @@ public:
 private:
     juce::OptionalScopedPointer<juce::AudioSource> source;
     juce::Array<std::pair<int, int>> remappedOutputs;
+    juce::Array<float> sourceChannelGain;
     int requiredNumberOfChannels;
 
     juce::AudioSampleBuffer buffer;

--- a/Source/MixerFader.h
+++ b/Source/MixerFader.h
@@ -6,6 +6,7 @@
 #include "ChangeableArrowButton.h"
 #include "LevelMeter.h"
 #include "MixerControlable.h"
+#include "PanSlider.h"
 #include "VolumeSlider.h"
 
 /**
@@ -81,7 +82,7 @@ private:
     std::unique_ptr<juce::TextButton> m_soloButton;
     std::unique_ptr<juce::TextButton> m_muteButton;
     ChangeableArrowButton m_expandButton;
-    std::unique_ptr<juce::Slider> m_panSlider;
+    std::unique_ptr<PanSlider> m_panSlider;
     LevelMeter m_levelMeter;
 
     ResizeCallback m_resizeCallback;

--- a/Source/PanSlider.cpp
+++ b/Source/PanSlider.cpp
@@ -1,0 +1,32 @@
+#include "PanSlider.h"
+
+#include "juce_audio_basics/juce_audio_basics.h"
+
+PanSlider::PanSlider()
+    : m_snapDistance(0.05)
+{
+    setRange(-1.0, 1.0, 0.01);
+    setValue(0.0);
+    setSliderStyle(juce::Slider::LinearHorizontal);
+    setTextBoxStyle(juce::Slider::NoTextBox, true, 0, 0);
+    setTransform(juce::AffineTransform().scaled(0.7f));
+}
+
+void PanSlider::paint(juce::Graphics& g)
+{
+    const int indent = juce::LookAndFeel::getDefaultLookAndFeel().getSliderThumbRadius(*this);
+    const float zeroPosition = static_cast<float>((1.0 - valueToProportionOfLength(0.0)) * (getWidth() - 2 * indent));
+
+    g.setColour(juce::Colours::black);
+    g.drawLine(indent + zeroPosition, 0.0f, indent + zeroPosition, static_cast<float>(getHeight()));
+
+    juce::Slider::paint(g);
+}
+
+double PanSlider::snapValue(double attemptedValue, juce::Slider::DragMode /*dragMode*/)
+{
+    if (std::abs(0.0 - attemptedValue) < m_snapDistance)
+        return 0.0;
+    else
+        return attemptedValue;
+}

--- a/Source/PanSlider.h
+++ b/Source/PanSlider.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "juce_gui_basics/juce_gui_basics.h"
+
+/* Slider to change panning.
+ *
+ * Its value ranges from -1 (full left) to 1 (full right). The UI snaps to 0
+ * which means center.
+ */
+class PanSlider : public juce::Slider
+{
+public:
+    PanSlider();
+
+protected:
+    // Distance in gain from 0 when to snap to 0.
+    double m_snapDistance;
+
+    // Slider
+public:
+    virtual void paint(juce::Graphics&) override;
+    virtual double snapValue(double attemptedValue, juce::Slider::DragMode dragMode) override;
+};

--- a/Source/Track.h
+++ b/Source/Track.h
@@ -126,12 +126,12 @@ private:
 
     // MixerControlable pan
 public:
-    virtual void setPan(float) override{};
-    virtual float getPan() const override
-    {
-        return 0;
-    };
+    virtual void setPan(float pan) override;
+    virtual float getPan() const override;
     virtual float getVolume() const override;
+
+private:
+    float m_pan;
 
     // MixerControlable name
 public:


### PR DESCRIPTION
Some code for this already existed but was always disabled because the `panEnabled` parameter was always set to `false`. This commit now adds the remaining changes necessary to be able to pan stereo player tracks.

The gain is applied in `ChannelRemappingAudioSourceWithVolume` similar to how the output channel mapping works with an array indexed by the source channel number.

The fader is implemented in `PanSlider` as a copy of the `VolumeSlider` with different visuals but the same features. Specifically it also snaps to a neutral position which is marked with a line.

The existing code placed the slider below the solo and mute buttons, squeezing the volume slider but leaving an empty label above. This isn't good use of the available space. Instead the pan slider now replaces the label for tracks.

The pan slider works in the value range -1.0 to 1.0 from which the gain values for both channels are calculated in `Track:setPan`.

closes #2 