### PR TITLE
Fix publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,10 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    needs: build
 
     steps:
-    - uses: actions/download-artifacts@v4
+    - uses: actions/download-artifact@v4
       with:
         merge-multiple: true
 


### PR DESCRIPTION
The name of the action was wrong, leading to:

    Error: Unable to resolve action actions/download-artifacts, repository not found

The publish job also started before the build job. Fixed by adding the missing dependency.