### PR TITLE
Fix passing parameters to changelog action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,8 @@ jobs:
       id: changelog
       uses: 3liz/changelog-release@0.2.0
       with:
-        INPUT_CHANGELOG_FILE: Changelog.md
-        ADD_EMOJIS: false
+        changelog_file: Changelog.md
+        add_emojis: false
 
     - name: Release
       uses: softprops/action-gh-release@v2


### PR DESCRIPTION
When running the action GitHub showed a warning:

    Unexpected input(s) 'INPUT_CHANGELOG_FILE', valid inputs are ['entryPoint', 'args', 'tag_name', 'changelog_file', 'add_emojis', 'emoji_end_of_line', 'add_raw_changelog_link', 'allow_failure']

Remove the wrong 'INPUT_' prefix and use lower case as in the warning and because it's nicer to read.