### PR TITLE
Make Changelog available in publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
     needs: build
 
     steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
     - uses: actions/download-artifact@v4
       with:
         merge-multiple: true


### PR DESCRIPTION
The changelog isn't an artifact but in the repository itself. So in addition to downloading the build artifacts the repository must also be checked out.